### PR TITLE
Refactored (UI) - removed scaling to fix layouts

### DIFF
--- a/src/app/analyze/page.tsx
+++ b/src/app/analyze/page.tsx
@@ -117,14 +117,14 @@ export default function PlaylistAnalyzer() {
   }, [playlistData])
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-white p-4 flex items-center justify-center">
-      <Card className="w-full max-w-6xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl 2xl:scale-150">
-        <CardContent className="p-6 flex flex-col min-h-[700px] relative">
+    <div className="min-h-screen bg-zinc-950 text-white p-2 sm:p-4 lg:p-6 xl:p-8 flex items-center justify-center">
+      <Card className="w-full max-w-sm sm:max-w-md md:max-w-lg lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl">
+        <CardContent className="p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 flex flex-col min-h-[500px] sm:min-h-[600px] md:min-h-[700px] lg:min-h-[800px] relative">
           {/* Header - Always visible */}
           <Header />
 
           {/* Main Content Area */}
-          <div className="flex-1 flex flex-col pb-20">
+          <div className="flex-1 flex flex-col pb-16 sm:pb-20 md:pb-24">
             {/* Welcome Message - Only shown initially */}
             {!playlistData && <FeatureCard type="analyze" />}
 
@@ -269,10 +269,10 @@ export default function PlaylistAnalyzer() {
           </div>
 
           {/* Input Area - Always visible at the bottom */}
-          <div className="absolute bottom-0 left-0 right-0 p-6 bg-black border-zinc-800 rounded-2xl">
-            <div className="flex space-x-2 w-2/3 mx-auto">
+          <div className="absolute bottom-0 left-0 right-0 p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 bg-black border-zinc-800 rounded-2xl">
+            <div className="flex space-x-2 w-full sm:w-5/6 md:w-4/5 lg:w-3/4 xl:w-2/3 mx-auto">
               <Input
-                className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full"
+                className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full text-sm md:text-base"
                 placeholder="Enter YouTube Playlist ID..."
                 value={playlistUrl}
                 onChange={(e) => setplaylistUrl(e.target.value)}

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -165,13 +165,13 @@ const YouTubeComparison = () => {
   }
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-white p-4 flex items-center justify-center">
+    <div className="min-h-screen bg-zinc-950 text-white p-2 sm:p-4 lg:p-6 xl:p-8 flex items-center justify-center">
       <Card
-        className={`w-full max-w-6xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl 2xl:scale-150 ${
-          comparisonData ? 'scale-90 2xl:scale-125' : ''
+        className={`w-full max-w-sm sm:max-w-md md:max-w-lg lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl ${
+          comparisonData ? 'lg:max-w-5xl xl:max-w-6xl 2xl:max-w-7xl' : ''
         }`}
       >
-        <CardContent className="p-6 flex flex-col min-h-[700px] relative">
+        <CardContent className="p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 flex flex-col min-h-[500px] sm:min-h-[600px] md:min-h-[700px] lg:min-h-[800px] relative">
           {/* Header - Always visible */}
           <Header />
 
@@ -440,26 +440,32 @@ const YouTubeComparison = () => {
           </div>
 
           {/* Input Area - Always visible at the bottom */}
-          <div className="absolute bottom-0 left-0 right-0 p-6 bg-black border-t border-zinc-800 rounded-b-2xl">
-            <form onSubmit={handleComparison} className="flex flex-col space-y-2 w-2/3 mx-auto">
-              <div className="flex space-x-2">
+          <div className="absolute bottom-0 left-0 right-0 p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 bg-black border-t border-zinc-800 rounded-b-2xl">
+            <form
+              onSubmit={handleComparison}
+              className="flex flex-col space-y-2 w-full sm:w-5/6 md:w-4/5 lg:w-3/4 xl:w-2/3 mx-auto"
+            >
+              <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
                 <Input
                   type="text"
                   value={firstVideoUrl}
                   onChange={(e) => setFirstVideoUrl(e.target.value)}
                   placeholder="Enter first YouTube video URL..."
-                  className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full"
+                  className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full text-sm md:text-base"
                 />
-                <ArrowRight className="w-6 h-6 text-gray-400" />
+                <ArrowRight className="w-6 h-6 text-gray-400 hidden sm:block" />
+                <div className="flex justify-center sm:hidden">
+                  <ArrowRight className="w-6 h-6 text-gray-400 rotate-90" />
+                </div>
                 <Input
                   type="text"
                   value={secondVideoUrl}
                   onChange={(e) => setSecondVideoUrl(e.target.value)}
                   placeholder="Enter second YouTube video URL..."
-                  className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full"
+                  className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full text-sm md:text-base"
                 />
               </div>
-              <div className="flex justify-center">
+              <div className="flex justify-center pt-2">
                 <FancyButton
                   onClick={(e) => {
                     e.preventDefault()

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -63,13 +63,13 @@ export default function StatsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-white p-4 flex items-center justify-center">
+    <div className="min-h-screen bg-zinc-950 text-white p-2 sm:p-4 lg:p-6 xl:p-8 flex items-center justify-center">
       <Card
-        className={`w-full max-w-6xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl 2xl:scale-150 ${
-          channelData ? 'scale-90 2xl:scale-125' : ''
+        className={`w-full max-w-sm sm:max-w-md md:max-w-lg lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl ${
+          channelData ? 'lg:max-w-5xl xl:max-w-6xl 2xl:max-w-7xl' : ''
         }`}
       >
-        <CardContent className="p-6 flex flex-col min-h-[700px] relative">
+        <CardContent className="p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 flex flex-col min-h-[500px] sm:min-h-[600px] md:min-h-[700px] lg:min-h-[800px] relative">
           {/* Header - Always visible */}
           <Header />
 
@@ -426,14 +426,17 @@ export default function StatsPage() {
           </div>
 
           {/* Input Area - Always visible at the bottom */}
-          <div className="absolute bottom-0 left-0 right-0 p-6 bg-black border-t border-zinc-800 rounded-b-2xl">
-            <form onSubmit={handleSubmit} className="flex space-x-2 w-2/3 mx-auto">
+          <div className="absolute bottom-0 left-0 right-0 p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 bg-black border-t border-zinc-800 rounded-b-2xl">
+            <form
+              onSubmit={handleSubmit}
+              className="flex space-x-2 w-full sm:w-5/6 md:w-4/5 lg:w-3/4 xl:w-2/3 mx-auto"
+            >
               <Input
                 type="text"
                 value={channelUrl}
                 onChange={(e) => setChannelUrl(e.target.value)}
                 placeholder="Enter YouTube channel URL..."
-                className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full"
+                className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full text-sm md:text-base"
               />
               <FancyButton
                 onClick={(e) => {

--- a/src/app/summarize/page.tsx
+++ b/src/app/summarize/page.tsx
@@ -715,18 +715,18 @@ export default function Home() {
   }, [])
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-white p-4 flex items-center justify-center">
+    <div className="min-h-screen bg-zinc-950 text-white p-2 sm:p-4 lg:p-6 xl:p-8 flex items-center justify-center">
       <Card
-        className={`w-full max-w-6xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl 2xl:scale-150 ${
-          videoDetails && transcriptData.length > 0 ? 'scale-90 2xl:scale-125' : ''
+        className={`w-full max-w-sm sm:max-w-md md:max-w-lg lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl ${
+          videoDetails && transcriptData.length > 0 ? 'lg:max-w-5xl xl:max-w-6xl 2xl:max-w-7xl' : ''
         }`}
       >
-        <CardContent className="p-6 flex flex-col min-h-[700px] relative">
+        <CardContent className="p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 flex flex-col min-h-[500px] sm:min-h-[600px] md:min-h-[700px] lg:min-h-[800px] relative">
           {/* Header - Always visible */}
           <Header />
 
           {/* Main Content Area */}
-          <div className="flex-1 flex flex-col pb-20">
+          <div className="flex-1 flex flex-col pb-16 sm:pb-20 md:pb-24 lg:pb-28">
             {/* Welcome Message - Only shown initially */}
             {!videoDetails && <FeatureCard type="summarize" />}
 
@@ -916,11 +916,14 @@ export default function Home() {
           </div>
 
           {/* Input Area - Always visible at the bottom */}
-          <div className="absolute bottom-0 left-0 right-0 p-6 bg-black border-t border-zinc-800 rounded-b-2xl">
-            <form onSubmit={handleSubmission} className="flex space-x-2 w-2/3 mx-auto">
-              <div>
+          <div className="absolute bottom-0 left-0 right-0 p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 bg-black border-t border-zinc-800 rounded-b-2xl">
+            <form
+              onSubmit={handleSubmission}
+              className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2 w-full sm:w-5/6 md:w-4/5 lg:w-3/4 xl:w-2/3 mx-auto"
+            >
+              <div className="w-full sm:w-auto">
                 <Select value={selectedLLM} onValueChange={setSelectedLLM}>
-                  <SelectTrigger className="w-[180px]">
+                  <SelectTrigger className="w-full sm:w-[180px]">
                     <SelectValue placeholder="Select LLM" />
                   </SelectTrigger>
                   <SelectContent>
@@ -965,7 +968,7 @@ export default function Home() {
                 value={videoUrl}
                 onChange={(e) => setVideoUrl(e.target.value)}
                 placeholder="Enter YouTube video URL..."
-                className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full"
+                className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full text-sm md:text-base"
               />
               <FancyButton
                 onClick={(e) => {

--- a/src/app/transcribe/page.tsx
+++ b/src/app/transcribe/page.tsx
@@ -196,13 +196,15 @@ export default function Home() {
   return (
     <>
       <script src="https://www.youtube.com/iframe_api" />
-      <div className="min-h-screen bg-zinc-950 text-white p-4 flex items-center justify-center">
+      <div className="min-h-screen bg-zinc-950 text-white p-2 sm:p-4 lg:p-6 xl:p-8 flex items-center justify-center">
         <Card
-          className={`w-full max-w-6xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl 2xl:scale-150 ${
-            videoDetails && transcriptData.length > 0 ? 'scale-90 2xl:scale-125' : ''
+          className={`w-full max-w-sm sm:max-w-md md:max-w-lg lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl bg-black border-zinc-800 shadow-xl shadow-stone-600 rounded-2xl ${
+            videoDetails && transcriptData.length > 0
+              ? 'lg:max-w-5xl xl:max-w-6xl 2xl:max-w-7xl'
+              : ''
           }`}
         >
-          <CardContent className="p-6 flex flex-col min-h-[700px] relative">
+          <CardContent className="p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 flex flex-col min-h-[500px] sm:min-h-[600px] md:min-h-[700px] lg:min-h-[800px] relative">
             {/* Header - Always visible */}
             <Header />
 
@@ -372,14 +374,17 @@ export default function Home() {
             </div>
 
             {/* Input Area - Always visible at the bottom */}
-            <div className="absolute bottom-0 left-0 right-0 p-6 bg-black border-t border-zinc-800 rounded-b-2xl">
-              <form onSubmit={handleSubmissiom} className="flex space-x-2 w-2/3 mx-auto">
+            <div className="absolute bottom-0 left-0 right-0 p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10 bg-black border-t border-zinc-800 rounded-b-2xl">
+              <form
+                onSubmit={handleSubmissiom}
+                className="flex space-x-2 w-full sm:w-5/6 md:w-4/5 lg:w-3/4 xl:w-2/3 mx-auto"
+              >
                 <Input
                   type="text"
                   value={videoUrl}
                   onChange={(e) => setVideoUrl(e.target.value)}
                   placeholder="Enter YouTube video URL..."
-                  className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full"
+                  className="flex-1 bg-transparent shadow-md shadow-gray-700 border-zinc-700 rounded-full text-sm md:text-base"
                 />
                 <FancyButton
                   onClick={(e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/hsr/FeatureCard.tsx
+++ b/src/components/hsr/FeatureCard.tsx
@@ -93,46 +93,50 @@ const FeatureCard = ({ type }: FeatureCardProps) => {
   const [Icon1, Icon2, Icon3] = [...content.icons]
 
   return (
-    <div className="text-center my-12">
-      <div className="bg-zinc-800 w-12 h-12 rounded-lg flex items-center justify-center mx-auto mb-6">
+    <div className="text-center my-6 sm:my-8 md:my-10 lg:my-12">
+      <div className="bg-zinc-800 w-8 h-8 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-lg flex items-center justify-center mx-auto mb-4 sm:mb-5 md:mb-6">
         <img
-          className="w-8 h-8"
+          className="w-5 h-5 sm:w-6 sm:h-6 md:w-8 md:h-8"
           src="https://img.icons8.com/arcade/64/youtube-play.png"
           alt="youtube-play"
         />
       </div>
-      <h1 className="text-2xl font-semibold mb-2">{content.heading}</h1>
-      <h2 className="text-xl text-zinc-400 mb-4">{content.subheading}</h2>
-      <p className="text-sm text-zinc-500 mb-8">
+      <h1 className="text-lg sm:text-xl md:text-2xl lg:text-3xl font-semibold mb-1 sm:mb-2">
+        {content.heading}
+      </h1>
+      <h2 className="text-base sm:text-lg md:text-xl lg:text-2xl text-zinc-400 mb-2 sm:mb-3 md:mb-4">
+        {content.subheading}
+      </h2>
+      <p className="text-xs sm:text-sm md:text-base text-zinc-500 mb-4 sm:mb-6 md:mb-8 px-2 sm:px-4">
         {content.caption}
         <br />
         {content.value}
       </p>
 
       {/* Feature Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-[8rem] px-10 w-3/4 ml-32">
-        <Card className="bg-gradient-to-br from-stone-700 via-transparent to-gray-900 border-zinc-700 p-4">
-          <div className="flex space-x-3 mt-2">
-            <Icon1 className="w-5 h-5 mb-1" />
-            <h3 className="font-medium mb-1">{content.fh1}</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 mt-8 sm:mt-12 md:mt-16 lg:mt-32 px-4 sm:px-6 md:px-8 lg:px-10 w-full sm:w-5/6 md:w-4/5 lg:w-3/4 mx-auto">
+        <Card className="bg-gradient-to-br from-stone-700 via-transparent to-gray-900 border-zinc-700 p-3 sm:p-4">
+          <div className="flex space-x-2 sm:space-x-3 mt-1 sm:mt-2">
+            <Icon1 className="w-4 h-4 sm:w-5 sm:h-5 mb-1 flex-shrink-0" />
+            <h3 className="font-medium mb-1 text-sm sm:text-base">{content.fh1}</h3>
           </div>
-          <p className="text-xs text-zinc-400">{content.fc1}</p>
+          <p className="text-xs sm:text-sm text-zinc-400 ml-6 sm:ml-8">{content.fc1}</p>
         </Card>
 
-        <Card className="bg-gradient-to-br from-stone-700 via-transparent to-gray-900 border-zinc-700 p-4">
-          <div className="flex space-x-3 mt-2">
-            <Icon2 className="w-5 h-5 mb-3" />
-            <h3 className="font-medium mb-1">{content.fh2}</h3>
+        <Card className="bg-gradient-to-br from-stone-700 via-transparent to-gray-900 border-zinc-700 p-3 sm:p-4">
+          <div className="flex space-x-2 sm:space-x-3 mt-1 sm:mt-2">
+            <Icon2 className="w-4 h-4 sm:w-5 sm:h-5 mb-1 flex-shrink-0" />
+            <h3 className="font-medium mb-1 text-sm sm:text-base">{content.fh2}</h3>
           </div>
-          <p className="text-xs text-zinc-400">{content.fc2}</p>
+          <p className="text-xs sm:text-sm text-zinc-400 ml-6 sm:ml-8">{content.fc2}</p>
         </Card>
 
-        <Card className="bg-gradient-to-br from-stone-700 via-transparent to-gray-900 border-zinc-700 p-4">
-          <div className="flex space-x-3 mt-2">
-            <Icon3 className="w-5 h-5 mb-3" />
-            <h3 className="font-medium mb-1">{content.fh3}</h3>
+        <Card className="bg-gradient-to-br from-stone-700 via-transparent to-gray-900 border-zinc-700 p-3 sm:p-4 sm:col-span-2 lg:col-span-1">
+          <div className="flex space-x-2 sm:space-x-3 mt-1 sm:mt-2">
+            <Icon3 className="w-4 h-4 sm:w-5 sm:h-5 mb-1 flex-shrink-0" />
+            <h3 className="font-medium mb-1 text-sm sm:text-base">{content.fh3}</h3>
           </div>
-          <p className="text-xs text-zinc-400">{content.fc3}</p>
+          <p className="text-xs sm:text-sm text-zinc-400 ml-6 sm:ml-8">{content.fc3}</p>
         </Card>
       </div>
     </div>

--- a/src/components/hsr/header.tsx
+++ b/src/components/hsr/header.tsx
@@ -8,23 +8,23 @@ import { useRouter } from 'next/navigation'
 const Header = () => {
   const router = useRouter()
   return (
-    <div className="flex items-center space-x-2 mb-6">
-      <div className="bg-zinc-800 p-2 rounded-lg">
+    <div className="flex items-center space-x-2 mb-4 sm:mb-5 md:mb-6">
+      <div className="bg-zinc-800 p-1.5 sm:p-2 rounded-lg">
         <img
-          className="w-5 h-5"
+          className="w-4 h-4 sm:w-5 sm:h-5"
           src="https://img.icons8.com/arcade/64/youtube-play.png"
           alt="youtube-play"
         />
       </div>
-      <span className="text-sm text-zinc-400">Yottly</span>
+      <span className="text-xs sm:text-sm text-zinc-400">Yottly</span>
       <div className="ml-auto">
         <Button
           variant="ghost"
           size="icon"
-          className="rounded-full"
+          className="rounded-full w-8 h-8 sm:w-10 sm:h-10"
           onClick={() => router.push('/dashboard')}
         >
-          <Undo2 className="w-5 h-5" />
+          <Undo2 className="w-4 h-4 sm:w-5 sm:h-5" />
         </Button>
       </div>
     </div>


### PR DESCRIPTION
This PR removes all use of `scale-*` utility classes and replaces them with **tailored, breakpoint-based responsive sizing** using Tailwind CSS. 

---

## 🔧 Main Changes

### 🧼 Removed:

* All `scale-*` classes across the following pages:

  * `/stats`
  * `/analyze`
  * `/compare`
  * `/summarize`
  * `/transcribe`

---


#### **Container Widths by Breakpoint:**

```txt
sm   → max-w-sm   (384px)
md   → max-w-md   (448px)
lg   → max-w-lg   (512px)
xl   → max-w-4xl  (896px)
2xl  → max-w-6xl  (1152px)
>2xl → max-w-7xl  (1280px)
```

#### **Container Padding:**

```ts
p-3 sm:p-4 md:p-6 lg:p-8 xl:p-10
```

#### **Outer Section Padding:**

```ts
p-2 sm:p-4 lg:p-6 xl:p-8
```

#### **Min Heights (for vertical space management):**

```ts
min-h-[500px] sm:min-h-[600px] md:min-h-[700px] lg:min-h-[800px]
```

---

### Input Area:

```ts
Width:   w-full → sm:w-5/6 → md:w-4/5 → lg:w-3/4 → xl:w-2/3
Text sizes:  text-sm → md:text-base
```

---

### Special Mobile Layouts:

* **Compare Page:** Vertical stacking + rotated arrow on mobile
* **Summarize Page:** LLM selector stacks above input field on mobile

---

### Component-Level Improvements:

* **FeatureCard:** Responsive grid layout, spacing, and text sizes
* **Header:** Icon and text sizes scale based on screen width

---